### PR TITLE
Fix error logging bug, memory retrieval logic, and typos

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export default {
 			console.error(
 				JSON.stringify({
 					name: e.name,
-					messages: e.messages,
+					message: e.message,
 					stack: e.stack,
 				}),
 			);
@@ -174,7 +174,9 @@ Email Body: ${email.html ?? email.text}`;
 								ids.push(match.id);
 							}
 						}
-					} else {
+					}
+
+					if (ids.length === 0) {
 						return {
 							success: false,
 							error: "No matching memories found for the text received, you may try again with different text.",
@@ -239,10 +241,10 @@ async function handleNewEmail(message: ForwardableEmailMessage, email: Email, en
 		rateLimited = true;
 		console.log(`Rate limited ${email.from.address} for today for using ${todayEmails.results.total} emails :/`);
 		modelResponse = {
-			response: `## You just reached today\'s limit for AskEmail :(
+			response: `## You just reached today's limit for AskEmail :(
 But don't worry, this will reset today at midnight UTC`,
 			subject: "You just reached today's limit for AskEmail :(",
-			html: await marked.parse(`## You just reached today\'s limit for AskEmail :(
+			html: await marked.parse(`## You just reached today's limit for AskEmail :(
 But don't worry, this will reset today at midnight UTC`),
 		};
 	} else {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,5 +1,5 @@
-export const SYSTEM_PROMPT_RESPONSE = `You are a useful AI Assistance from the project AskEmail
-Your task is to help users by answering their emails and executing the tasks their ask you to.
+export const SYSTEM_PROMPT_RESPONSE = `You are a useful AI Assistant from the project AskEmail
+Your task is to help users by answering their emails and executing the tasks they ask you to.
 Make sure to always answer in the same language as the user, and to always be very responsive.
 If a user asks you to remember something, please call the saveInMemory function, this will save the user message (not including files) and a text from your choice that should represent what the user asked you to remember.
 If a user asks you directly or indirectly something that you think you should remember, please call the getFromMemory with the text you are trying to remember, this function will then give you up to three memories related to the text you sent.


### PR DESCRIPTION
## Summary

This PR fixes several small bugs and typos:

- **Fix error logging**: `e.messages` → `e.message` in the catch handler (`index.ts:24`). The `messages` property doesn't exist on Error objects, so the error message was always logged as `undefined`.

- **Fix memory retrieval logic**: The `getFromMemory` tool previously only returned an error when `vectorQuery.matches` was empty. If matches existed but all had scores below the 0.65 threshold, the `ids` array would be empty, causing `whereIn("id", [])` to produce invalid SQL. Now it checks `ids.length === 0` after filtering, which correctly handles both cases.

- **Fix typos in system prompt**: "AI Assistance" → "AI Assistant", "tasks their ask you to" → "tasks they ask you to"

- **Remove unnecessary escape sequences**: `\'` in template literals doesn't need escaping — removed the backslashes.

## Why this is beneficial

- Error logs now actually contain the error message, making debugging possible
- Memory retrieval no longer produces invalid SQL when vector matches are below threshold
- System prompt is grammatically correct, improving LLM instruction quality

## Test plan

- [x] `npx @biomejs/biome check src/` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)